### PR TITLE
新图传链路，更改了比较多东西

### DIFF
--- a/MDK-ARM/.eide/eide.json
+++ b/MDK-ARM/.eide/eide.json
@@ -258,6 +258,9 @@
           },
           {
             "path": "../User/Device/GraphicsSendTask.cpp"
+          },
+          {
+            "path": "../User/Device/dvc_VT13.cpp"
           }
         ],
         "folders": []

--- a/User/Chariot/crt_booster.h
+++ b/User/Chariot/crt_booster.h
@@ -42,6 +42,13 @@ enum Enum_Booster_Control_Type
     Booster_Control_Type_MULTI,  //连发
 };
 
+enum Enum_Booster_User_Control_Type
+{
+    Booster_User_Control_Type_DISABLE = 0,
+    Booster_User_Control_Type_SINGLE,
+    Booster_User_Control_Type_MULTI, // 连发
+};
+
 /**
  * @brief 摩擦轮控制类型
  *
@@ -121,6 +128,8 @@ public:
 
     void TIM_Calculate_PeriodElapsedCallback();
 	void Output();
+
+    Enum_Booster_User_Control_Type Booster_User_Control_Type = Booster_User_Control_Type_SINGLE;
 		
 protected:
     //初始化相关常量

--- a/User/Chariot/crt_chassis.cpp
+++ b/User/Chariot/crt_chassis.cpp
@@ -89,7 +89,8 @@ void Class_Tricycle_Chassis::Speed_Resolution(){
             }            
         }
         break;
-		case (Chassis_Control_Type_SPIN) :
+		case (Chassis_Control_Type_SPIN_Positive) :
+        case (Chassis_Control_Type_SPIN_NePositive) :
         case (Chassis_Control_Type_FLLOW):
         {
             //底盘四电机模式配置

--- a/User/Chariot/crt_chassis.h
+++ b/User/Chariot/crt_chassis.h
@@ -50,7 +50,8 @@ enum Enum_Chassis_Control_Type :uint8_t
 {
     Chassis_Control_Type_DISABLE = 0,
     Chassis_Control_Type_FLLOW,
-    Chassis_Control_Type_SPIN,
+    Chassis_Control_Type_SPIN_Positive,
+    Chassis_Control_Type_SPIN_NePositive,
 };
 
 /**

--- a/User/Congfig/config.h
+++ b/User/Congfig/config.h
@@ -16,8 +16,8 @@
 
 /* Exported macros -----------------------------------------------------------*/
 
-#define CHASSIS
-//#define GIMBAL
+//#define CHASSIS
+#define GIMBAL
 
 
 #ifdef CHASSIS 	
@@ -30,6 +30,14 @@
     #endif
 
     //#define SPEED_SLOPE
+
+#endif
+
+#ifdef GIMBAL
+
+    #define USE_VT13
+
+    //#define USE_DR16
 
 #endif
 

--- a/User/Device/dvc_VT13.cpp
+++ b/User/Device/dvc_VT13.cpp
@@ -1,0 +1,304 @@
+#include "dvc_VT13.h"
+
+/**
+ * @brief Get the crc16 checksum
+ *
+ * @param p_msg Data to check
+ * @param lenData length
+ * @param crc16 Crc16 initialized checksum
+ * @return crc16 Crc16 checksum
+ */
+static uint16_t get_crc16_check_sum(uint8_t *p_msg, uint16_t len, uint16_t crc16)
+{
+    uint8_t data;
+
+    if(p_msg == NULL)
+    {
+        return 0xffff;
+    }
+
+    while(len--)
+    {
+        data = *p_msg++;
+        (crc16) = ((uint16_t)(crc16) >> 8) ^ crc16_tab[((uint16_t)(crc16) ^ (uint16_t)(data)) & 0x00ff];
+    }
+
+    return crc16;
+}
+
+/**
+ * @brief crc16 verify function
+ *
+ * @param p_msg Data to verify
+ * @param len Stream length=data+checksum
+ * @return bool Crc16 check result
+ */
+bool verify_crc16_check_sum(uint8_t *p_msg, uint16_t len)
+{
+    uint16_t w_expected = 0;
+
+    if((p_msg == NULL) || (len <= 2))
+    {
+        return false;
+    }
+    w_expected = get_crc16_check_sum(p_msg, len - 2, crc16_init);
+
+    return ((w_expected & 0xff) == p_msg[len - 2] && ((w_expected >> 8) & 0xff) == p_msg[len - 1]);
+}
+
+void Class_VT13::VT13_UART_RxCpltCallback(uint8_t *Rx_Data)
+{ 
+  if(*(Rx_Data + 0) != 0xA9 || *(Rx_Data + 1) != 0x53){
+    return;
+  }
+ 
+  if(!verify_crc16_check_sum(Rx_Data, 21)){
+    return;
+  }
+
+  VT13_Flag ++;
+
+  VT13_Data_Process(Rx_Data);
+
+  memcpy(&Pre_RX_Data,Rx_Data,sizeof(Struct_VT13_UART_Data));
+  
+}
+
+void Class_VT13::TIM1msMod50_Alive_PeriodElapsedCallback()
+{
+
+  if(VT13_Flag == VT13_Pre_Flag)
+  {
+    VT13_Status = VT13_Status_DISABLE;
+    Unline_Cnt ++;
+  }
+  else
+  {
+    VT13_Status = VT13_Status_ENABLE;
+    Unline_Cnt = 0;
+  }
+
+  VT13_Pre_Flag = VT13_Flag;
+}
+
+void Class_VT13::Judeg_Trigger(Enum_VT13_Trigger_Status *Trigger, uint8_t Status, uint8_t Pre_Status)
+{
+  switch(Pre_Status){
+    case(VT13_Trigger_FREE):
+    {
+      switch (Status)
+      {
+        case(VT13_Trigger_FREE):
+        {
+          *Trigger = VT13_Trigger_FREE;
+        }
+        break;
+        case(VT13_Trigger_PRESSED):
+        {
+          *Trigger = VT13_Trigger_TRIG_FREE_PRESSED;
+        }
+        break;
+      }
+    }
+    break;
+    case(VT13_Button_PRESSED):
+    {
+      switch (Status)
+      {
+        case(VT13_Trigger_PRESSED):
+        {
+          *Trigger = VT13_Trigger_PRESSED;
+        }
+        break;
+        case(VT13_Trigger_FREE):
+        {
+          *Trigger = VT13_Trigger_TRIG_PRESSED_FREE;
+        }
+        break;
+      }
+    }
+    break;
+  }
+}
+
+void Class_VT13::Judge_Button(Enum_VT13_Button_Status *Button, uint8_t Status, uint8_t Pre_Status)
+{
+  switch(Pre_Status){
+    case(VT13_Button_FREE):
+    {
+      switch (Status)
+      {
+        case(VT13_Button_FREE):
+        {
+          *Button = VT13_Button_FREE;
+        }
+        break;
+        case(VT13_Button_PRESSED):
+        {
+          *Button = VT13_Button_TRIG_FREE_PRESSED;
+        }
+        break;
+      }
+    }
+    break;
+    case(VT13_Button_PRESSED):
+    {
+      switch (Status)
+      {
+        case(VT13_Button_PRESSED):
+        {
+          *Button = VT13_Button_PRESSED;
+        }
+        break;
+        case(VT13_Button_FREE):
+        {
+          *Button = VT13_Button_TRIG_PRESSED_FREE;
+        }
+        break;
+      }
+    }
+    break;
+  }
+}
+
+void Class_VT13::Judge_Switch(Enum_VT13_Switch_Status *Switch, uint8_t Status, uint8_t Pre_Status)
+{
+  switch(Pre_Status){
+    case(VT13_Switch_Status_Left):
+    {
+      switch(Status){
+        case(VT13_Switch_Status_Left):
+        {
+          *Switch = VT13_Switch_Status_Left;
+        }
+        break;
+        case(VT13_Switch_Status_Middle):
+        {
+          *Switch = VT13_Switch_Status_TRIG_Left_Middle;
+        }
+        break;
+        case(VT13_Switch_Status_Right):
+        {
+          *Switch = VT13_Switch_Status_TRIG_Left_Right;
+        }
+        break;
+      }
+    }
+    break;
+    case(VT13_Switch_Status_Middle):
+    {
+      switch(Status){
+        case(VT13_Switch_Status_Middle):
+        {
+          *Switch = VT13_Switch_Status_Middle;
+        }
+        break;
+        case(VT13_Switch_Status_Left):
+        {
+          *Switch = VT13_Switch_Status_TRIG_Middle_Left;
+        }
+        break;
+        case(VT13_Switch_Status_Right):
+        {
+          *Switch = VT13_Switch_Status_TRIG_Middle_Right;
+        }
+        break;
+      }
+    }
+    break;
+    case(VT13_Switch_Status_Right):
+    {
+      switch(Status){
+        case(VT13_Switch_Status_Right):
+        {
+          *Switch = VT13_Switch_Status_Right;
+        }
+        break;
+        case(VT13_Switch_Status_Middle):
+        {
+          *Switch = VT13_Switch_Status_TRIG_Right_Middle;
+        }
+        break;
+        case(VT13_Switch_Status_Left):
+        {
+          *Switch = VT13_Switch_Status_TRIG_Right_Left;
+        }
+        break;
+      }
+    }
+    break;
+  }
+}
+
+void Class_VT13::Judge_Key(Enum_VT13_Key_Status *Key, uint8_t Status, uint8_t Pre_Status)
+{
+  switch(Pre_Status){
+    case(VT13_Key_Status_FREE):
+    {
+      switch (Status)
+      {
+        case(VT13_Key_Status_FREE):
+        {
+          *Key = VT13_Key_Status_FREE;
+        }
+        break;
+        case(VT13_Key_Status_PRESSED):
+        {
+          *Key = VT13_Key_Status_TRIG_FREE_PRESSED;
+        }
+        break;
+      }
+    }
+    break;
+    case(VT13_Key_Status_PRESSED):
+    {
+      switch (Status)
+      {
+        case(VT13_Key_Status_PRESSED):
+        {
+          *Key = VT13_Key_Status_PRESSED;
+        }
+        break;
+        case(VT13_Key_Status_FREE):
+        {
+          *Key = VT13_Key_Status_TRIG_PRESSED_FREE;
+        }
+        break;
+      }
+    }
+    break;
+  }
+}
+
+void Class_VT13::VT13_Data_Process(uint8_t *Rx_Data)
+{
+  memcpy(&Now_RX_Data, Rx_Data, sizeof(Struct_VT13_UART_Data));
+
+  VT13_Data.Right_X = (float)(Now_RX_Data.ch_0 - Rocker_Offset)/Rocker_Num;
+  VT13_Data.Right_Y = (float)(Now_RX_Data.ch_1 - Rocker_Offset)/Rocker_Num;
+  VT13_Data.Left_Y  = (float)(Now_RX_Data.ch_2 - Rocker_Offset)/Rocker_Num;
+  VT13_Data.Left_X  = (float)(Now_RX_Data.ch_3 - Rocker_Offset)/Rocker_Num;
+  
+  VT13_Data.Yaw     = (float)(Now_RX_Data.wheel - Rocker_Offset) / Rocker_Num;
+
+  Judeg_Trigger(&VT13_Data.Trigger, Now_RX_Data.trigger, Pre_RX_Data.trigger); 
+  Judge_Button(&VT13_Data.Pause_Key, Now_RX_Data.pause, Pre_RX_Data.pause);
+  Judge_Button(&VT13_Data.Button_Left, Now_RX_Data.fn_1, Pre_RX_Data.fn_1);
+  Judge_Button(&VT13_Data.Button_Right, Now_RX_Data.fn_2, Pre_RX_Data.fn_2);
+
+  Judge_Switch(&VT13_Data.Switch, Now_RX_Data.mode_sw, Pre_RX_Data.mode_sw);
+
+  VT13_Data.Mouse_X = Now_RX_Data.mouse_x / 32768.0f;
+  VT13_Data.Mouse_Y = Now_RX_Data.mouse_y / 32768.0f;
+  VT13_Data.Mouse_Z = Now_RX_Data.mouse_z / 32768.0f;
+
+  Judge_Key(&VT13_Data.Mouse_Key_Left, Now_RX_Data.mouse_left, Pre_RX_Data.mouse_left);
+  Judge_Key(&VT13_Data.Mouse_Key_Right, Now_RX_Data.mouse_right, Pre_RX_Data.mouse_right);
+  Judge_Key(&VT13_Data.Mouse_Key_Middle, Now_RX_Data.mouse_middle, Pre_RX_Data.mouse_middle);
+  
+  // 判断键盘触发
+  for (int i = 0; i < 16; i++)
+  {
+      Judge_Key(&VT13_Data.Keyboard_Key[i], ((Now_RX_Data.key) >> i) & 0x1, ((Pre_RX_Data.key) >> i) & 0x1);
+  }
+}

--- a/User/Device/dvc_VT13.h
+++ b/User/Device/dvc_VT13.h
@@ -1,0 +1,372 @@
+#ifndef DVC_VT13_H
+
+#define DVC_VT13_H
+
+#include "stdint.h"
+#include "string.h"
+
+#define KEY_W 0
+#define KEY_S 1
+#define KEY_A 2
+#define KEY_D 3
+#define KEY_SHIFT 4
+#define KEY_CTRL 5
+#define KEY_Q 6
+#define KEY_E 7
+#define KEY_R 8
+#define KEY_F 9
+#define KEY_G 10
+#define KEY_Z 11
+#define KEY_X 12
+#define KEY_C 13
+#define KEY_V 14
+#define KEY_B 15
+
+enum Enum_VT13_Status{
+  VT13_Status_DISABLE = 0,
+  VT13_Status_ENABLE,
+};
+
+enum Enum_VT13_Trigger_Status{
+  VT13_Trigger_FREE = 0,
+  VT13_Trigger_PRESSED,
+  VT13_Trigger_TRIG_FREE_PRESSED,
+  VT13_Trigger_TRIG_PRESSED_FREE,
+  
+};
+
+enum Enum_VT13_Button_Status{
+  VT13_Button_FREE = 0,
+  VT13_Button_PRESSED, 
+  VT13_Button_TRIG_FREE_PRESSED,
+  VT13_Button_TRIG_PRESSED_FREE,
+};
+
+enum Enum_VT13_Switch_Status{
+  VT13_Switch_Status_Left = 0,
+  VT13_Switch_Status_Middle,
+  VT13_Switch_Status_Right,
+  
+  VT13_Switch_Status_TRIG_Left_Middle,      //左到中突变
+  VT13_Switch_Status_TRIG_Middle_Left,      
+
+  VT13_Switch_Status_TRIG_Middle_Right,     //中到右突变
+  VT13_Switch_Status_TRIG_Right_Middle,
+
+  VT13_Switch_Status_TRIG_Left_Right,
+  VT13_Switch_Status_TRIG_Right_Left,
+};
+
+enum Enum_VT13_Key_Status
+{
+  VT13_Key_Status_FREE = 0,           //松开状态
+  VT13_Key_Status_PRESSED,            //按下状态
+  VT13_Key_Status_TRIG_FREE_PRESSED,  //松开到按下的突变状态
+  VT13_Key_Status_TRIG_PRESSED_FREE,  //按下到松开的突变状态
+};
+
+struct Struct_VT13_UART_Data
+{
+    uint8_t sof_1;                    //帧头1
+    uint8_t sof_2;                    //帧头2
+    uint64_t ch_0:11;                 //右X
+    uint64_t ch_1:11;                 //右Y
+    uint64_t ch_2:11;                 //左Y
+    uint64_t ch_3:11;                 //左X
+    uint64_t mode_sw:2;
+    uint64_t pause:1;
+    uint64_t fn_1:1;
+    uint64_t fn_2:1;
+    uint64_t wheel:11;
+    uint64_t trigger:1;
+
+    int16_t mouse_x;
+    int16_t mouse_y;
+    int16_t mouse_z;
+    uint8_t mouse_left:2;
+    uint8_t mouse_right:2;
+    uint8_t mouse_middle:2;
+    uint16_t key;
+    uint16_t crc16;
+}__attribute__((packed)); 
+
+struct Struct_VT13_Data{
+
+  float Left_X;
+  float Left_Y;
+  float Right_X;
+  float Right_Y;
+  float Yaw;
+
+  Enum_VT13_Button_Status Button_Left;
+  Enum_VT13_Button_Status Button_Right;
+  Enum_VT13_Button_Status Pause_Key;
+  Enum_VT13_Trigger_Status Trigger;
+  Enum_VT13_Switch_Status Switch;
+
+  float Mouse_X;
+  float Mouse_Y;
+  float Mouse_Z;
+  Enum_VT13_Key_Status Mouse_Key_Left;
+  Enum_VT13_Key_Status Mouse_Key_Right;
+  Enum_VT13_Key_Status Mouse_Key_Middle;
+  Enum_VT13_Key_Status Keyboard_Key[16];
+};
+
+static uint16_t get_crc16_check_sum(uint8_t *p_msg, uint16_t len, uint16_t crc16);
+
+static uint16_t crc16_init = 0xffff;
+static const uint16_t crc16_tab[256] =
+{
+    0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf,
+    0x8c48, 0x9dc1, 0xaf5a, 0xbed3, 0xca6c, 0xdbe5, 0xe97e, 0xf8f7,
+    0x1081, 0x0108, 0x3393, 0x221a, 0x56a5, 0x472c, 0x75b7, 0x643e,
+    0x9cc9, 0x8d40, 0xbfdb, 0xae52, 0xdaed, 0xcb64, 0xf9ff, 0xe876,
+    0x2102, 0x308b, 0x0210, 0x1399, 0x6726, 0x76af, 0x4434, 0x55bd,
+	0xad4a, 0xbcc3, 0x8e58, 0x9fd1, 0xeb6e, 0xfae7, 0xc87c, 0xd9f5,
+	0x3183, 0x200a, 0x1291, 0x0318, 0x77a7, 0x662e, 0x54b5, 0x453c,
+	0xbdcb, 0xac42, 0x9ed9, 0x8f50, 0xfbef, 0xea66, 0xd8fd, 0xc974,
+	0x4204, 0x538d, 0x6116, 0x709f, 0x0420, 0x15a9, 0x2732, 0x36bb,
+	0xce4c, 0xdfc5, 0xed5e, 0xfcd7, 0x8868, 0x99e1, 0xab7a, 0xbaf3,
+	0x5285, 0x430c, 0x7197, 0x601e, 0x14a1, 0x0528, 0x37b3, 0x263a,
+	0xdecd, 0xcf44, 0xfddf, 0xec56, 0x98e9, 0x8960, 0xbbfb, 0xaa72,
+	0x6306, 0x728f, 0x4014, 0x519d, 0x2522, 0x34ab, 0x0630, 0x17b9,
+	0xef4e, 0xfec7, 0xcc5c, 0xddd5, 0xa96a, 0xb8e3, 0x8a78, 0x9bf1,
+	0x7387, 0x620e, 0x5095, 0x411c, 0x35a3, 0x242a, 0x16b1, 0x0738,
+	0xffcf, 0xee46, 0xdcdd, 0xcd54, 0xb9eb, 0xa862, 0x9af9, 0x8b70,
+	0x8408, 0x9581, 0xa71a, 0xb693, 0xc22c, 0xd3a5, 0xe13e, 0xf0b7,
+	0x0840, 0x19c9, 0x2b52, 0x3adb, 0x4e64, 0x5fed, 0x6d76, 0x7cff,
+	0x9489, 0x8500, 0xb79b, 0xa612, 0xd2ad, 0xc324, 0xf1bf, 0xe036,
+	0x18c1, 0x0948, 0x3bd3, 0x2a5a, 0x5ee5, 0x4f6c, 0x7df7, 0x6c7e,
+	0xa50a, 0xb483, 0x8618, 0x9791, 0xe32e, 0xf2a7, 0xc03c, 0xd1b5,
+	0x2942, 0x38cb, 0x0a50, 0x1bd9, 0x6f66, 0x7eef, 0x4c74, 0x5dfd,
+	0xb58b, 0xa402, 0x9699, 0x8710, 0xf3af, 0xe226, 0xd0bd, 0xc134,
+	0x39c3, 0x284a, 0x1ad1, 0x0b58, 0x7fe7, 0x6e6e, 0x5cf5, 0x4d7c,
+	0xc60c, 0xd785, 0xe51e, 0xf497, 0x8028, 0x91a1, 0xa33a, 0xb2b3,
+	0x4a44, 0x5bcd, 0x6956, 0x78df, 0x0c60, 0x1de9, 0x2f72, 0x3efb,
+	0xd68d, 0xc704, 0xf59f, 0xe416, 0x90a9, 0x8120, 0xb3bb, 0xa232,
+	0x5ac5, 0x4b4c, 0x79d7, 0x685e, 0x1ce1, 0x0d68, 0x3ff3, 0x2e7a,
+	0xe70e, 0xf687, 0xc41c, 0xd595, 0xa12a, 0xb0a3, 0x8238, 0x93b1,
+	0x6b46, 0x7acf, 0x4854, 0x59dd, 0x2d62, 0x3ceb, 0x0e70, 0x1ff9,
+	0xf78f, 0xe606, 0xd49d, 0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330,
+	0x7bc7, 0x6a4e, 0x58d5, 0x495c, 0x3de3, 0x2c6a, 0x1ef1, 0x0f78
+};
+
+class Class_VT13
+{
+  public:
+
+  inline Enum_VT13_Status Get_VT13_Status();
+
+  inline float Get_Right_X();
+  inline float Get_Right_Y();
+  inline float Get_Left_X();
+  inline float Get_Left_Y();
+  inline float Get_Yaw();
+  inline Enum_VT13_Switch_Status Get_Switch();
+  inline Enum_VT13_Button_Status Get_Button_Left();
+  inline Enum_VT13_Button_Status Get_Button_Right();
+  inline Enum_VT13_Trigger_Status Get_Trigger();
+
+  inline float Get_Mouse_X();
+  inline float Get_Mouse_Y();
+  inline float Get_Mouse_Z();
+  inline Enum_VT13_Key_Status Get_Mouse_Left_Key();
+  inline Enum_VT13_Key_Status Get_Mouse_Right_Key();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_W();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_S();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_A();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_D();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_Shift();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_Ctrl();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_Q();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_E();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_R();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_F();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_G();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_Z();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_X();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_C();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_V();
+  inline Enum_VT13_Key_Status Get_Keyboard_Key_B();
+
+  void VT13_UART_RxCpltCallback(uint8_t *Rx_Data);
+  void TIM1msMod50_Alive_PeriodElapsedCallback();
+
+  private:
+
+  const int16_t Min_Channel_Num = 364;
+  const int16_t Max_Channel_Num = 1684;
+  const float Rocker_Offset = 1024.0f;
+  const float Rocker_Num = 660.0f;
+
+  uint16_t Unline_Cnt = 0;
+
+  int32_t VT13_Flag;
+  int32_t VT13_Pre_Flag;
+
+  Enum_VT13_Status VT13_Status;
+
+  Struct_VT13_UART_Data Now_RX_Data;
+  Struct_VT13_UART_Data Pre_RX_Data;
+
+  Struct_VT13_Data VT13_Data;
+
+  void Judeg_Trigger(Enum_VT13_Trigger_Status *Trigger, uint8_t Status, uint8_t Pre_Status);
+  void Judge_Button(Enum_VT13_Button_Status *Button, uint8_t Status, uint8_t Pre_Status);
+  void Judge_Switch(Enum_VT13_Switch_Status *Switch, uint8_t Status, uint8_t Pre_Status);
+  void Judge_Key(Enum_VT13_Key_Status *Key, uint8_t Status, uint8_t Pre_Status);
+  void VT13_Data_Process(uint8_t *Rx_Data);
+
+};
+
+inline float Class_VT13::Get_Right_X(){
+  return (VT13_Data.Right_X);
+}
+
+inline float Class_VT13::Get_Right_Y(){
+  return (VT13_Data.Right_Y);
+}
+
+inline float Class_VT13::Get_Left_X(){
+  return (VT13_Data.Left_X);
+}
+
+inline float Class_VT13::Get_Left_Y(){
+  return (VT13_Data.Left_Y);
+}
+
+inline Enum_VT13_Switch_Status Class_VT13::Get_Switch()
+{
+  return (VT13_Data.Switch);
+}
+
+inline Enum_VT13_Button_Status Class_VT13::Get_Button_Left()
+{
+  return (VT13_Data.Button_Left);
+}
+
+inline Enum_VT13_Button_Status Class_VT13::Get_Button_Right()
+{
+  return (VT13_Data.Button_Right);
+}
+
+inline Enum_VT13_Trigger_Status Class_VT13::Get_Trigger()
+{
+  return (VT13_Data.Trigger);
+}
+
+float Class_VT13::Get_Yaw(){
+  return (VT13_Data.Yaw);
+}
+
+inline float Class_VT13::Get_Mouse_X()
+{
+  return (VT13_Data.Mouse_X);
+}
+
+inline float Class_VT13::Get_Mouse_Y()
+{
+  return (VT13_Data.Mouse_Y);
+}
+
+inline float Class_VT13::Get_Mouse_Z()
+{
+  return (VT13_Data.Mouse_Z);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Mouse_Left_Key()
+{
+  return (VT13_Data.Mouse_Key_Left);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Mouse_Right_Key()
+{
+  return (VT13_Data.Mouse_Key_Right);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_W()
+{
+  return (VT13_Data.Keyboard_Key[KEY_W]);
+}
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_S()
+{
+  return (VT13_Data.Keyboard_Key[KEY_S]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_A()
+{
+  return (VT13_Data.Keyboard_Key[KEY_A]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_D()
+{
+  return (VT13_Data.Keyboard_Key[KEY_D]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_Shift()
+{
+  return (VT13_Data.Keyboard_Key[KEY_SHIFT]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_Ctrl()
+{
+  return (VT13_Data.Keyboard_Key[KEY_CTRL]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_Q()
+{
+  return (VT13_Data.Keyboard_Key[KEY_Q]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_E()
+{
+  return (VT13_Data.Keyboard_Key[KEY_E]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_R()
+{
+  return (VT13_Data.Keyboard_Key[KEY_R]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_F()
+{
+  return (VT13_Data.Keyboard_Key[KEY_F]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_G()
+{
+  return (VT13_Data.Keyboard_Key[KEY_G]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_Z()
+{
+  return (VT13_Data.Keyboard_Key[KEY_Z]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_X()
+{
+  return (VT13_Data.Keyboard_Key[KEY_X]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_C()
+{
+  return (VT13_Data.Keyboard_Key[KEY_C]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_V()
+{
+  return (VT13_Data.Keyboard_Key[KEY_V]);
+}
+
+inline Enum_VT13_Key_Status Class_VT13::Get_Keyboard_Key_B()
+{
+  return (VT13_Data.Keyboard_Key[KEY_B]);
+}
+
+inline Enum_VT13_Status Class_VT13::Get_VT13_Status()
+{
+  return (VT13_Status);
+}
+
+#endif

--- a/User/Interaction/ita_chariot.h
+++ b/User/Interaction/ita_chariot.h
@@ -15,6 +15,7 @@
 /* Includes ------------------------------------------------------------------*/
 
 #include "dvc_dr16.h"
+#include "dvc_VT13.h"
 #include "crt_gimbal.h"
 #include "crt_booster.h"
 #include "dvc_imu.h"
@@ -97,12 +98,33 @@ enum Enum_DR16_Control_Type
 };
 
 /**
+ * @brief VT13控制数据来源
+ *
+ */
+enum Enum_VT13_Control_Type
+{
+    VT13_Control_Type_REMOTE = 0,
+    VT13_Control_Type_KEYBOARD,
+
+    VT13_Control_Type_NONE,
+};
+
+/**
  * @brief 机器人是否离线 控制模式有限自动机
  *
  */
 class Class_FSM_Alive_Control : public Class_FSM
 {
 public:
+    Class_Chariot *Chariot;
+
+    void Reload_TIM_Status_PeriodElapsedCallback();
+};
+
+class Class_FSM_Alive_Control_VT13 : public Class_FSM
+{
+    public:
+    uint8_t Start_Flag = 0;     //记录第一次上电开机，以初始化状态
     Class_Chariot *Chariot;
 
     void Reload_TIM_Status_PeriodElapsedCallback();
@@ -132,6 +154,8 @@ public:
     #ifdef GIMBAL
         //遥控器
         Class_DR16 DR16;
+
+        Class_VT13 VT13;
         //上位机
         Class_MiniPC MiniPC;
         //云台
@@ -143,9 +167,11 @@ public:
         Class_FSM_Alive_Control FSM_Alive_Control;
         friend class Class_FSM_Alive_Control;
 
+        Class_FSM_Alive_Control_VT13 FSM_Alive_Control_VT13;
+        friend class Class_FSM_Alive_Control_VT13;
     #endif
 
-    void Init(float __DR16_Dead_Zone = 0);
+    void Init(float __Dead_Zone = 0);
     
     #ifdef CHASSIS
 
@@ -170,6 +196,7 @@ public:
 
         inline Enum_Chassis_Status Get_Chassis_Status();
         inline Enum_DR16_Control_Type Get_DR16_Control_Type();
+        inline Enum_VT13_Control_Type Get_VT13_Control_Type();
 
         void CAN_Gimbal_Rx_Chassis_Callback();
         void CAN_Gimbal_Tx_Chassis_Callback();
@@ -225,31 +252,31 @@ protected:
 
     #ifdef GIMBAL
         //遥控器拨动的死区, 0~1
-        float DR16_Dead_Zone;
+        float Dead_Zone;
         //常量
         //键鼠模式按住shift 最大速度缩放系数
-        float DR16_Mouse_Chassis_Shift = 2.0f;
+        float Mouse_Chassis_Shift = 2.0f;
         //舵机占空比 默认关闭弹舱
         uint16_t Compare =400;
         //DR16底盘加速灵敏度系数(0.001表示底盘加速度最大为1m/s2)
-        float DR16_Keyboard_Chassis_Speed_Resolution_Small = 0.001f;
+        float Keyboard_Chassis_Speed_Resolution_Small = 0.001f;
         //DR16底盘减速灵敏度系数(0.001表示底盘加速度最大为1m/s2)
-        float DR16_Keyboard_Chassis_Speed_Resolution_Big = 0.01f;
+        float Keyboard_Chassis_Speed_Resolution_Big = 0.01f;
 
         //DR16云台yaw灵敏度系数(0.001PI表示yaw速度最大时为1rad/s)
-        float DR16_Yaw_Angle_Resolution = 0.005f * PI * 57.29577951308232;
+        float Yaw_Angle_Resolution = 0.005f * PI * 57.29577951308232;
         //DR16云台pitch灵敏度系数(0.001PI表示pitch速度最大时为1rad/s)
-        float DR16_Pitch_Angle_Resolution = 0.003f * PI * 57.29577951308232;
+        float Pitch_Angle_Resolution = 0.003f * PI * 57.29577951308232;
 
         //DR16云台yaw灵敏度系数(0.001PI表示yaw速度最大时为1rad/s)
-        float DR16_Yaw_Resolution = 0.003f * PI;
+        float Yaw_Resolution = 0.003f * PI;
         //DR16云台pitch灵敏度系数(0.001PI表示pitch速度最大时为1rad/s)
-        float DR16_Pitch_Resolution = 0.003f * PI;
+        float Pitch_Resolution = 0.003f * PI;
 
         //DR16鼠标云台yaw灵敏度系数, 不同鼠标不同参数
-        float DR16_Mouse_Yaw_Angle_Resolution = 57.8*4.0f;
+        float Mouse_Yaw_Angle_Resolution = 57.8*4.0f;
         //DR16鼠标云台pitch灵敏度系数, 不同鼠标不同参数
-        float DR16_Mouse_Pitch_Angle_Resolution = 57.8f;
+        float Mouse_Pitch_Angle_Resolution = 57.8f;
         
         //迷你主机云台pitch自瞄控制系数
         float MiniPC_Autoaiming_Yaw_Angle_Resolution = 0.003f;
@@ -280,9 +307,11 @@ protected:
         uint8_t Shoot_Flag = 0;
         //DR16控制数据来源
         Enum_DR16_Control_Type DR16_Control_Type = DR16_Control_Type_NONE;
+        Enum_VT13_Control_Type VT13_Control_Type = VT13_Control_Type_NONE;
         //内部函数
 
         void Judge_DR16_Control_Type();
+        void Judge_VT13_Control_Type();
 
         void Control_Chassis();
         void Control_Gimbal();
@@ -319,6 +348,16 @@ protected:
         return (DR16_Control_Type);
     }
 
+     /**
+     * @brief 获取VT13控制数据来源
+     * 
+     * @return VT13_Control_Type
+     */
+    inline Enum_VT13_Control_Type Class_Chariot::Get_VT13_Control_Type()
+    {
+      return (VT13_Control_Type);
+    }
+    
     /**
      * @brief 获取前一帧底盘控制类型
      * 

--- a/User/Task/tsk_config_and_callback.cpp
+++ b/User/Task/tsk_config_and_callback.cpp
@@ -290,8 +290,15 @@ void DR16_UART3_Callback(uint8_t *Buffer, uint16_t Length)
 
     //底盘 云台 发射机构 的控制策略
     chariot.TIM_Control_Callback();
-		
-	
+}
+
+
+void VT13_UART_Callback(uint8_t *Buffer, uint16_t Length)
+{
+    chariot.VT13.VT13_UART_RxCpltCallback(Buffer);
+
+    //底盘 云台 发射机构 的控制策略
+    chariot.TIM_Control_Callback();
 }
 #endif
 
@@ -382,7 +389,15 @@ void Task1ms_TIM5_Callback()
     if(start_flag==1)
     {
         #ifdef GIMBAL
+        #ifdef USE_DR16
+
         chariot.FSM_Alive_Control.Reload_TIM_Status_PeriodElapsedCallback();
+
+        #elif defined(USE_VT13)
+
+        chariot.FSM_Alive_Control_VT13.Reload_TIM_Status_PeriodElapsedCallback();
+
+        #endif
         #endif
         chariot.TIM_Calculate_PeriodElapsedCallback();
         
@@ -441,8 +456,12 @@ extern "C" void Task_Init()
         IIC_Init(&hi2c3, Ist8310_IIC3_Callback);    
         
         //遥控器接收
+        #ifdef USE_DR16
         UART_Init(&huart3, DR16_UART3_Callback, 18);
 		UART_Init(&huart6, Image_UART6_Callback, 40);
+        #elif defined(USE_VT13)
+        UART_Init(&huart6, VT13_UART_Callback, 30);
+        #endif
 
         //上位机USB
         USB_Init(&MiniPC_USB_Manage_Object,MiniPC_USB_Callback);


### PR DESCRIPTION
VT13图传链路
1. 使用宏定义USE_DR16, USE_VT13宏定义区分DR16，VT13，不同时使用
2. 底盘控制模式，小陀螺增加Positive（正转），NePositive（反转）模式，方便用扳机切换小陀螺转向
3. 键鼠控制逻辑是参考M54步兵的控制方式，故新增了枚举Enum_Booster_User_Control_Type
4. 将可以通用的一些定义，如遥控器死区，遥控器灵敏度，键鼠灵敏度的前缀DR16去掉
5. 新增文件dvc_VT13.cpp .h（大部分与DR16.cpp类似），以及VT13的离线状态机（抄的DR16）